### PR TITLE
Fixed MySQL Queries

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -44,15 +44,15 @@ CREATE TABLE IF NOT EXISTS users (
 	passbcrypt VARCHAR(64) DEFAULT '',
 	otpsecret VARCHAR(64) DEFAULT '',
 	yubikey VARCHAR(128) DEFAULT '',
-	sshkeys TEXT DEFAULT '',
-	custattr TEXT DEFAULT '{}')
+	sshkeys TEXT,
+	custattr TEXT)
 `)
 	statement.Exec()
 	statement, _ = db.Prepare("CREATE UNIQUE INDEX idx_user_name on users(name)")
 	statement.Exec()
-	statement, _ = db.Prepare("CREATE TABLE IF NOT EXISTS groups (id INTEGER AUTO_INCREMENT PRIMARY KEY, name VARCHAR(64) NOT NULL, gidnumber INTEGER NOT NULL)")
+	statement, _ = db.Prepare("CREATE TABLE IF NOT EXISTS `groups` (id INTEGER AUTO_INCREMENT PRIMARY KEY, name VARCHAR(64) NOT NULL, gidnumber INTEGER NOT NULL)")
 	statement.Exec()
-	statement, _ = db.Prepare("CREATE UNIQUE INDEX idx_group_name on groups(name)")
+	statement, _ = db.Prepare("CREATE UNIQUE INDEX idx_group_name on `groups`(name)")
 	statement.Exec()
 	statement, _ = db.Prepare("CREATE TABLE IF NOT EXISTS includegroups (id INTEGER AUTO_INCREMENT PRIMARY KEY, parentgroupid INTEGER NOT NULL, includegroupid INTEGER NOT NULL)")
 	statement.Exec()
@@ -63,7 +63,7 @@ CREATE TABLE IF NOT EXISTS users (
 // Migrate schema if necessary
 func (b MysqlBackend) MigrateSchema(db *sql.DB, checker func(*sql.DB, string) bool) {
 	if !checker(db, "sshkeys") {
-		statement, _ := db.Prepare("ALTER TABLE users ADD COLUMN sshkeys TEXT DEFAULT ''")
+		statement, _ := db.Prepare("ALTER TABLE users ADD COLUMN sshkeys TEXT")
 		statement.Exec()
 	}
 }


### PR DESCRIPTION
There are some issues with queries:

1. TEXT column can't have a default value (related to `sshkeys` & `custattr` from `users` table)
2. `GROUPS` is a reserved word in MySQL, which means we either rename the table or use between backticks (I have used backticks in order to not change any implementation)