### PR TITLE
Update mysql schema

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"fmt"
 
 	_ "github.com/go-sql-driver/mysql"
 
@@ -50,9 +51,9 @@ CREATE TABLE IF NOT EXISTS users (
 	statement.Exec()
 	statement, _ = db.Prepare("CREATE UNIQUE INDEX idx_user_name on users(name)")
 	statement.Exec()
-	statement, _ = db.Prepare("CREATE TABLE IF NOT EXISTS `groups` (id INTEGER AUTO_INCREMENT PRIMARY KEY, name VARCHAR(64) NOT NULL, gidnumber INTEGER NOT NULL)")
+	statement, _ = db.Prepare("CREATE TABLE IF NOT EXISTS ldapgroups (id INTEGER AUTO_INCREMENT PRIMARY KEY, name VARCHAR(64) NOT NULL, gidnumber INTEGER NOT NULL)")
 	statement.Exec()
-	statement, _ = db.Prepare("CREATE UNIQUE INDEX idx_group_name on `groups`(name)")
+	statement, _ = db.Prepare("CREATE UNIQUE INDEX idx_group_name on ldapgroups(name)")
 	statement.Exec()
 	statement, _ = db.Prepare("CREATE TABLE IF NOT EXISTS includegroups (id INTEGER AUTO_INCREMENT PRIMARY KEY, parentgroupid INTEGER NOT NULL, includegroupid INTEGER NOT NULL)")
 	statement.Exec()
@@ -66,4 +67,24 @@ func (b MysqlBackend) MigrateSchema(db *sql.DB, checker func(*sql.DB, string) bo
 		statement, _ := db.Prepare("ALTER TABLE users ADD COLUMN sshkeys TEXT DEFAULT ('')")
 		statement.Exec()
 	}
+
+	if TableExists(db, "`groups`") {
+		// Drop the table created during schema creation
+		statement, _ := db.Prepare("DROP TABLE ldapgroups")
+		statement.Exec()
+
+		statement, _ = db.Prepare("ALTER TABLE `groups` RENAME ldapgroups")
+		statement.Exec()
+	}
+}
+
+// Indicates whether the table exists or not
+func TableExists(db *sql.DB, tableName string) bool {
+	var found string
+	err := db.QueryRow(fmt.Sprintf("SELECT COUNT(id) FROM %s", tableName)).Scan(
+		&found)
+	if err != nil {
+		return false
+	}
+	return true
 }

--- a/mysql.go
+++ b/mysql.go
@@ -44,15 +44,15 @@ CREATE TABLE IF NOT EXISTS users (
 	passbcrypt VARCHAR(64) DEFAULT '',
 	otpsecret VARCHAR(64) DEFAULT '',
 	yubikey VARCHAR(128) DEFAULT '',
-	sshkeys TEXT DEFAULT '',
-	custattr TEXT DEFAULT '{}')
+	sshkeys TEXT DEFAULT (''),
+	custattr TEXT DEFAULT ('{}'))
 `)
 	statement.Exec()
 	statement, _ = db.Prepare("CREATE UNIQUE INDEX idx_user_name on users(name)")
 	statement.Exec()
-	statement, _ = db.Prepare("CREATE TABLE IF NOT EXISTS groups (id INTEGER AUTO_INCREMENT PRIMARY KEY, name VARCHAR(64) NOT NULL, gidnumber INTEGER NOT NULL)")
+	statement, _ = db.Prepare("CREATE TABLE IF NOT EXISTS `groups` (id INTEGER AUTO_INCREMENT PRIMARY KEY, name VARCHAR(64) NOT NULL, gidnumber INTEGER NOT NULL)")
 	statement.Exec()
-	statement, _ = db.Prepare("CREATE UNIQUE INDEX idx_group_name on groups(name)")
+	statement, _ = db.Prepare("CREATE UNIQUE INDEX idx_group_name on `groups`(name)")
 	statement.Exec()
 	statement, _ = db.Prepare("CREATE TABLE IF NOT EXISTS includegroups (id INTEGER AUTO_INCREMENT PRIMARY KEY, parentgroupid INTEGER NOT NULL, includegroupid INTEGER NOT NULL)")
 	statement.Exec()
@@ -63,7 +63,7 @@ CREATE TABLE IF NOT EXISTS users (
 // Migrate schema if necessary
 func (b MysqlBackend) MigrateSchema(db *sql.DB, checker func(*sql.DB, string) bool) {
 	if !checker(db, "sshkeys") {
-		statement, _ := db.Prepare("ALTER TABLE users ADD COLUMN sshkeys TEXT DEFAULT ''")
+		statement, _ := db.Prepare("ALTER TABLE users ADD COLUMN sshkeys TEXT DEFAULT ('')")
 		statement.Exec()
 	}
 }


### PR DESCRIPTION
The groups keyword is reserved in mysql but can still have tables using this name if they are quoted with backticks (`). Additionally, default values cannot be specified for TEXT types unless wrapped in parentheses.

This change updates the schema. Without this, glauth will crash immediately with a stack trace similar to:

```
Aug 14 16:06:18 violet glauth.glauth[1792776]: Mon, 14 Aug 2023 16:06:18 -0700 INF AP start
Aug 14 16:06:18 violet glauth.glauth[1792776]: panic: runtime error: invalid memory address or nil pointer dereference
Aug 14 16:06:18 violet glauth.glauth[1792776]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x7f744540aa82]
Aug 14 16:06:18 violet glauth.glauth[1792776]: goroutine 1 [running]:
Aug 14 16:06:18 violet glauth.glauth[1792776]: database/sql.(*Stmt).ExecContext(0x0, {0x1664e00, 0xc000028090}, {0x0, 0x0, 0x0})
Aug 14 16:06:18 violet glauth.glauth[1792776]:         /snap/go/10029/src/database/sql/sql.go:2619 +0x82
Aug 14 16:06:18 violet glauth.glauth[1792776]: database/sql.(*Stmt).Exec(...)
Aug 14 16:06:18 violet glauth.glauth[1792776]:         /snap/go/10029/src/database/sql/sql.go:2651
Aug 14 16:06:18 violet glauth.glauth[1792776]: plugin/unnamed-a4a88b6e149fb894e2d6a86bf6dd94628b70c962.MysqlBackend.CreateSchema({}, 0xc0002e6090?)
Aug 14 16:06:18 violet glauth.glauth[1792776]:         /root/parts/glauth/src/v2/pkg/plugins/glauth-mysql/mysql.go:50 +0x5d
Aug 14 16:06:18 violet glauth.glauth[1792776]: github.com/glauth/glauth/v2/pkg/plugins.NewDatabaseHandler({0x7f7445800270, 0x1e1e088}, {0xc0003746c0, 0x5, 0xc000380e01?})
Aug 14 16:06:18 violet glauth.glauth[1792776]:         /root/parts/glauth/src/v2/pkg/plugins/basesqlhandler.go:83 +0x3b1
Aug 14 16:06:18 violet glauth.glauth[1792776]: plugin/unnamed-a4a88b6e149fb894e2d6a86bf6dd94628b70c962.NewMySQLHandler({0xc0003746c0?, 0x28?, 0xc000140558?})
Aug 14 16:06:18 violet glauth.glauth[1792776]:         /root/parts/glauth/src/v2/pkg/plugins/glauth-mysql/mysql.go:17 +0x35
Aug 14 16:06:18 violet glauth.glauth[1792776]: github.com/glauth/glauth/v2/pkg/server.NewServer({0xc00031fd60, 0x2, 0x7?})
Aug 14 16:06:18 violet glauth.glauth[1792776]:         /root/parts/glauth/src/v2/pkg/server/server.go:127 +0x125c
Aug 14 16:06:18 violet glauth.glauth[1792776]: main.startService()
Aug 14 16:06:18 violet glauth.glauth[1792776]:         /root/parts/glauth/src/v2/glauth.go:160 +0x34f
Aug 14 16:06:18 violet glauth.glauth[1792776]: main.main()
Aug 14 16:06:18 violet glauth.glauth[1792776]:         /root/parts/glauth/src/v2/glauth.go:133 +0x225
```